### PR TITLE
Add wildcard support for replacements

### DIFF
--- a/src/main/java/com/jarhax/oretiers/compat/crt/OreTiersCrT.java
+++ b/src/main/java/com/jarhax/oretiers/compat/crt/OreTiersCrT.java
@@ -1,8 +1,10 @@
 package com.jarhax.oretiers.compat.crt;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.google.common.collect.Lists;
 import com.jarhax.oretiers.api.OreTiersAPI;
 import com.jarhax.oretiers.client.renderer.block.model.BakedModelTiered;
 
@@ -14,6 +16,7 @@ import minetweaker.api.item.IItemStack;
 import net.darkhax.bookshelf.util.GameUtils;
 import net.darkhax.bookshelf.util.RenderUtils;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockRedstoneOre;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.init.Blocks;
@@ -28,25 +31,25 @@ import stanhebben.zenscript.annotations.ZenMethod;
 @ZenClass("mods.OreTiers")
 public class OreTiersCrT {
 
-    public static void init () {
+    public static void init() {
 
         MineTweakerAPI.registerClass(OreTiersCrT.class);
 
         if (GameUtils.isClient()) {
 
-            MineTweakerImplementationAPI.onReloadEvent( (e) -> preLoad(e));
-            MineTweakerImplementationAPI.onPostReload( (e) -> postLoad(e));
+            MineTweakerImplementationAPI.onReloadEvent((e) -> preLoad(e));
+            MineTweakerImplementationAPI.onPostReload((e) -> postLoad(e));
         }
     }
 
     @SideOnly(Side.CLIENT)
-    public static void preLoad (ReloadEvent event) {
+    public static void preLoad(ReloadEvent event) {
 
         OreTiersAPI.enableReload();
     }
 
     @SideOnly(Side.CLIENT)
-    public static void postLoad (ReloadEvent event) {
+    public static void postLoad(ReloadEvent event) {
 
         boolean requireReload = false;
 
@@ -92,36 +95,45 @@ public class OreTiersCrT {
     }
 
     @ZenMethod
-    public static void addReplacement (String name, IIngredient original) {
+    public static void addReplacement(String name, IIngredient original) {
 
         addReplacement(name, original, Blocks.STONE.getDefaultState());
     }
 
     @ZenMethod
-    public static void addReplacement (String name, IIngredient original, IItemStack replacement) {
+    public static void addReplacement(String name, IIngredient original, IItemStack replacement) {
 
         addReplacement(name, original, getStateFromStack((ItemStack) replacement.getInternal()));
     }
 
-    private static void addReplacement (String name, IIngredient original, IBlockState replacementState) {
+    private static void addReplacement(String name, IIngredient original, IBlockState replacementState) {
 
         final Object internal = original.getInternal();
-
         if (internal instanceof Block) {
             MineTweakerAPI.apply(new ActionAddReplacement(name, ((Block) internal).getDefaultState(), replacementState));
-        }
-        else if (internal instanceof ItemStack) {
-            MineTweakerAPI.apply(new ActionAddReplacement(name, getStateFromStack((ItemStack) internal), replacementState));
-        }
-        else if (internal instanceof String) {
+        } else if (internal instanceof ItemStack) {
+            List<IBlockState> states = getStatesFromStack((ItemStack) internal);
+            for (IBlockState state : states)
+                MineTweakerAPI.apply(new ActionAddReplacement(name, state, replacementState));
+        } else if (internal instanceof String) {
             for (final ItemStack stack : OreDictionary.getOres((String) internal)) {
                 MineTweakerAPI.apply(new ActionAddReplacement(name, getStateFromStack(stack), replacementState));
             }
         }
     }
 
-    private static IBlockState getStateFromStack (ItemStack stack) {
+    private static List<IBlockState> getStatesFromStack(ItemStack stack) {
+        final Block block = Block.getBlockFromItem(stack.getItem());
+        if (stack.getMetadata() == OreDictionary.WILDCARD_VALUE) {
+            if(block instanceof BlockRedstoneOre) {
+                return Lists.newArrayList(Blocks.REDSTONE_ORE.getDefaultState(),Blocks.LIT_REDSTONE_ORE.getDefaultState());
+            }
+            return block.getBlockState().getValidStates();
+        }
+        return Lists.newArrayList(getStateFromStack(stack));
+    }
 
+    private static IBlockState getStateFromStack(ItemStack stack) {
         final Block block = Block.getBlockFromItem(stack.getItem());
         return block != null ? block.getStateFromMeta(stack.getMetadata()) : Blocks.STONE.getDefaultState();
     }


### PR DESCRIPTION
This allows wildcard support for ItemStacks by collecting all the valid states of the block, as well as special cases BlockRedstoneOre since LIT_REDSTONE_ORE does not have an ItemBlock.
[Video of it working](https://streamable.com/ofeaz)

If the redstone ore hack isn't good, the other option would be to register an ItemBlock for it so it can be found through an ItemStack.

A couple issues that I don't think can be solved without some major hacks are:
  * The particles created by lit redstone ore, only possible way seems to be substitution alias which in 1.11.2 just isn't worth any trouble.
  * With fences, the selection box can be easily fixed to show the replacement but I'm not sure the collision box can be controlled.  

Note: Sorry about the autoformat, can fix if necessary  